### PR TITLE
Output user root

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -70,7 +70,7 @@ on:
 jobs:
   bazel:
     name: ${{ inputs.name }}
-    runs-on: ${{ inputs.os == 'macos' && 'macos-13' || format('{0}-latest', inputs.os) }}
+    runs-on: ${{ inputs.os == 'macos' && 'macos-13' ||  inputs.os == 'windows' && 'windows-2019'  ||format('{0}-latest', inputs.os) }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SEL_M2_USER: ${{ secrets.SEL_M2_USER }}
@@ -91,10 +91,6 @@ jobs:
           rm "$env:ChromeWebDriver" -r -v
           rm "$env:EdgeWebDriver" -r -v
           rm "$env:GeckoWebDriver" -r -v
-      - name: Create .bazelrc file
-        if: inputs.os == 'windows'
-        run: |
-          echo "startup --output_user_root=D:/bzl" >> .bazelrc.local
       - name: Remove driver directories Non-Windows
         if: inputs.os != 'windows'
         run: |

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -91,6 +91,10 @@ jobs:
           rm "$env:ChromeWebDriver" -r -v
           rm "$env:EdgeWebDriver" -r -v
           rm "$env:GeckoWebDriver" -r -v
+      - name: Create .bazelrc file
+        if: inputs.os == 'windows'
+        run: |
+          echo "startup --output_user_root=D:/bzl" >> .bazelrc.local
       - name: Remove driver directories Non-Windows
         if: inputs.os != 'windows'
         run: |


### PR DESCRIPTION
### Description

The code in the pull request modifies the configuration for the GitHub Actions workflow file `bazel.yml`. More specifically, it updates the `runs-on` parameter to support running the job on different operating systems based on the input provided. This change ensures that the job runs on macOS, Windows, or the latest available version of the specified operating system.

Changes:
- Update the runs-on configuration to support running the job on macOS, Windows, or the latest specified OS version.

Impact:
- Previously, the job would only run on macOS-13 for macOS inputs.
- With the change, the job will now run on macOS-13 for macOS inputs, on windows-2019 for Windows inputs, and on the latest version for any other specified OS inputs.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Modify the GitHub Actions workflow to support running jobs on different operating systems based on input, including macOS-13, windows-2019, and the latest version of other specified OS inputs.

CI:
- Update the GitHub Actions workflow configuration to allow jobs to run on macOS-13 for macOS inputs, windows-2019 for Windows inputs, and the latest version for any other specified OS inputs.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the CI/CD workflow to support Windows operating system, enhancing compatibility and flexibility for projects requiring Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->